### PR TITLE
Add `target` and `rel` Attributes to `<Link />` Component

### DIFF
--- a/src/Link/Link.stories.tsx
+++ b/src/Link/Link.stories.tsx
@@ -1,12 +1,10 @@
-import { Link, ILink } from ".";
 import { BrowserRouter } from "react-router-dom";
-import { props, parameters } from "./props";
+import { Link, ILink } from ".";
+import { parameters, props } from "./props";
 
 const story = {
-  title: "navigation/Link",
-  component: Link,
-  parameters,
   argTypes: props,
+  component: Link,
   decorators: [
     (Story: React.ElementType) => (
       <BrowserRouter>
@@ -14,6 +12,8 @@ const story = {
       </BrowserRouter>
     ),
   ],
+  parameters,
+  title: "navigation/Link",
 };
 
 const Default = (args: ILink) => {
@@ -22,9 +22,11 @@ const Default = (args: ILink) => {
 
 Default.args = {
   children: "Link",
-  size: "large",
-  type: "body",
   path: "/",
+  rel: "noopener noreferrer",
+  size: "large",
+  target: "_self",
+  type: "body",
 };
 
 export { Default };

--- a/src/Link/index.tsx
+++ b/src/Link/index.tsx
@@ -1,16 +1,19 @@
+import { ILinkSize, ILinkType } from "./props";
 import { StyledLink } from "./styles";
-import { ILinkType, ILinkSize } from "./props";
+
 interface ILink {
   children: React.ReactNode;
-  size?: ILinkSize;
-  type?: ILinkType;
   path: string;
+  rel?: string;
+  size?: ILinkSize;
+  target?: string;
+  type?: ILinkType;
 }
 
 const Link = (props: ILink) => {
-  const { children, size = "large", type = "body", path } = props;
+  const { children, path, rel, size = "large", target, type = "body" } = props;
   return (
-    <StyledLink to={path} $size={size} $type={type}>
+    <StyledLink to={path} $size={size} $type={type} target={target} rel={rel}>
       {children}
     </StyledLink>
   );

--- a/src/Link/props.ts
+++ b/src/Link/props.ts
@@ -1,6 +1,6 @@
-const types = ["body", "display", "label", "title", "headline"] as const;
-
 const sizes = ["large", "medium", "small"] as const;
+
+const types = ["body", "display", "headline", "label", "title"] as const;
 
 type ILinkSize = (typeof sizes)[number];
 
@@ -16,6 +16,30 @@ const parameters = {
 };
 
 const props = {
+  children: {
+    control: { type: "text" },
+    description: "The text to be displayed",
+  },
+  hover: {
+    description: "Indicates when the mouse passes over the text",
+  },
+  path: {
+    description:
+      "is the path where the MenuLink is going to navigate and is required.",
+  },
+  rel: {
+    description:
+      "Specifies the relationship between the current and linked documents.",
+  },
+  size: {
+    options: sizes,
+    control: { type: "select" },
+    description:
+      "This prop is used to select one of the typography roles defined in the Foundations.",
+  },
+  target: {
+    description: "Specifies where to open the linked document.",
+  },
   type: {
     options: types,
     control: { type: "select" },
@@ -25,23 +49,7 @@ const props = {
       defaultValue: { summary: "bodyLarge" },
     },
   },
-  size: {
-    options: sizes,
-    control: { type: "select" },
-    description:
-      "This prop is used to select one of the typography roles defined in the Foundations.",
-  },
-  children: {
-    control: { type: "text" },
-    description: "The text to be displayed",
-  },
-  path: {
-    description:
-      "is the path where the MenuLink is going to navigate and is required.",
-  },
-  hover: {
-    description: "Indicates when the mouse passes over the text",
-  },
 };
-export { props, parameters };
+
+export { parameters, props };
 export type { ILinkSize, ILinkType };


### PR DESCRIPTION
This pull request enhances the `<Link />` component by adding support for the `target` and `rel` attributes. These attributes are essential for controlling how links behave, particularly when opening in new tabs, and for improving security by specifying relationships between linked documents.