### PR TITLE
Move link tokens from foundations to component

### DIFF
--- a/src/Link/Tokens/tokens.ts
+++ b/src/Link/Tokens/tokens.ts
@@ -1,0 +1,12 @@
+import { inube } from "@inubekit/foundations";
+
+const tokens = {
+  content: {
+    color: {
+      regular: inube.palette.blue.B400,
+      hover: inube.palette.blue.B300,
+    },
+  },
+};
+
+export { tokens };

--- a/src/Link/styles.js
+++ b/src/Link/styles.js
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 import { Link } from "react-router-dom";
-
 import { inube } from "@inubekit/foundations";
+import { tokens } from "./Tokens/tokens";
 
 const StyledLink = styled(Link)`
   font-family: ${({ theme, $type, $size }) =>
@@ -16,18 +16,16 @@ const StyledLink = styled(Link)`
   margin: ${({ $margin }) => $margin};
   text-align: ${({ $textAlign }) => $textAlign};
   color: ${({ theme }) => {
-    return (
-      theme?.link?.content?.color?.regular || inube.link.content.color.regular
-    );
+    return theme?.link?.content?.color?.regular || tokens.content.color.regular;
   }};
   cursor: pointer;
   text-decoration: none;
   &:hover {
     border-bottom: 1px solid
       ${({ theme }) =>
-        theme?.link?.content?.color?.hover || inube.link.content.color.hover};
+        theme?.link?.content?.color?.hover || tokens.content.color.hover};
     color: ${({ theme }) =>
-      theme?.link?.content?.color?.hover || inube.link.content.color.hover};
+      theme?.link?.content?.color?.hover || tokens.content.color.hover};
   }
 `;
 


### PR DESCRIPTION
This PR relocates the link tokens from the foundations folder to the component folder, updating all necessary imports to reflect the new structure and ensuring that components are referencing the correct token paths. This update enhances the organization, maintainability, and clarity of the codebase.